### PR TITLE
update: create schema field and use column as key in table creation

### DIFF
--- a/src/unitycatalog/resources/tables.py
+++ b/src/unitycatalog/resources/tables.py
@@ -93,7 +93,7 @@ class TablesResource(SyncAPIResource):
             body=maybe_transform(
                 {
                     "catalog_name": catalog_name,
-                    "schema": {"columns": columns},
+                    "schema": {"columns": columns },
                     "data_source_format": data_source_format,
                     "name": name,
                     "schema_name": schema_name,

--- a/src/unitycatalog/resources/tables.py
+++ b/src/unitycatalog/resources/tables.py
@@ -93,7 +93,7 @@ class TablesResource(SyncAPIResource):
             body=maybe_transform(
                 {
                     "catalog_name": catalog_name,
-                    "columns": columns,
+                    "schema": {"columns": columns},
                     "data_source_format": data_source_format,
                     "name": name,
                     "schema_name": schema_name,


### PR DESCRIPTION
To create a table using Data Catalog API version 2.1, we need to include a schema dictionary within the fields parameter. This schema dictionary should contain a key named columns.